### PR TITLE
truncate long genome name

### DIFF
--- a/bin/primer_designer_region.py
+++ b/bin/primer_designer_region.py
@@ -1636,8 +1636,11 @@ class Report():
             f'Created at {datetime.now().strftime("%d/%m/%Y %H:%M:%S")}'
         )
         lines.append(f'SNP file used: {Path(SNP).stem}')
+
+        ref_genome = Path(REFERENCE).stem
+        ref_genome = ref_genome[:70] if len(ref_genome) > 70 else ref_genome
         lines.append(
-            f'Human reference version: {ref} ({Path(REFERENCE).stem})')
+            f'Human reference version: {ref} ({ref_genome})')
 
         # add final footer text, split over lines as line breaks refused
         # to work and I don't care enough to debug reportlab

--- a/bin/primer_designer_region.py
+++ b/bin/primer_designer_region.py
@@ -1637,10 +1637,24 @@ class Report():
         )
         lines.append(f'SNP file used: {Path(SNP).stem}')
 
-        ref_genome = Path(REFERENCE).stem
-        ref_genome = ref_genome[:70] if len(ref_genome) > 70 else ref_genome
-        lines.append(
-            f'Human reference version: {ref} ({ref_genome})')
+        if len(Path(REFERENCE).stem) > 70:
+            # break long string into chunks of 70
+            long_string = Path(REFERENCE).stem
+            texts = [long_string[i:i+70] for i in range(0, len(long_string), 70)]
+            for idx, val in enumerate(texts):
+                if idx == 0:
+                    # first line
+                    lines.append(
+                        f'Human reference version: {ref} ({val}')
+                elif idx == len(texts) - 1:
+                    # last line
+                    lines.append(f'{val})')
+                else:
+                    # middle lines
+                    lines.append(val)
+        else:
+            lines.append(
+                f'Human reference version: {ref} ({Path(REFERENCE).stem})')
 
         # add final footer text, split over lines as line breaks refused
         # to work and I don't care enough to debug reportlab

--- a/test/test_primer_designer.py
+++ b/test/test_primer_designer.py
@@ -62,15 +62,11 @@ def run_test(args, genes_df):
 
         cmd = (
             "docker run "
-            "-v /home/jason/github/primer_designer/test/reference_files:/reference "
+            "-v /home/jason/github/reference:/reference "
             f"-v /home/jason/github/primer_designer/test/test_output:/home/primer_designer/output "
-            "--env REF_37=/reference/grch37/hs37d5.fa "
-            "--env SNP_37=/reference/grch37/gnomad.genomes.r2.0.1.sites.noVEP.AF-0.01.infoRemoved.vcf.gz "
-            "--env PRIMER_VERSION=2.0.0 "
-            "--env SNP37_VERSION=2.0.1 "
-            "--env SNP37_DB=gnomad "
-            "primer_designer:2.0.1 "
-            f"python -u bin/primer_designer_region.py --chr {chr} --pos {random_pos} --grch37"
+            "--env-file /home/jason/github/primer_designer/.env "
+            "primer_designer:2.0.2 "
+            f"python -u bin/primer_designer_region.py --chr {chr} --pos {random_pos} --grch38"
         )
 
         # call primer designer docker to generate report


### PR DESCRIPTION
# Changes
- truncate long genome name if too long

# Fix
#6 

# Example
[15_31360221.pdf](https://github.com/eastgenomics/primer_designer/files/9734366/15_31360221.pdf)
[14_74973977.pdf](https://github.com/eastgenomics/primer_designer/files/9734370/14_74973977.pdf)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/primer_designer/7)
<!-- Reviewable:end -->
